### PR TITLE
Add support to custom HTTP methods

### DIFF
--- a/tornado_cors/__init__.py
+++ b/tornado_cors/__init__.py
@@ -39,8 +39,10 @@ class CorsMixin(object):
         self.finish()
 
     def _get_methods(self):
+        supported_methods = [method.lower() for method in self.SUPPORTED_METHODS]
+        #  ['get', 'put', 'post', 'patch', 'delete', 'options']
         methods = []
-        for meth in ['get', 'put', 'post', 'patch', 'delete', 'options']:
+        for meth in supported_methods:
             instance_meth = getattr(self, meth)
             if not meth:
                 continue


### PR DESCRIPTION
Tornado CORS ignores custom HTTP methods, because currently supported methods are hard-coded.

This patch generalizes supported HTTP methods using the attribute SUPPORTED_METHODS, available at Tornado's RequestHandler class [1].

This "bug" was found while implementing the "PURGE" method at Brainiak API [2].

[1] http://www.tornadoweb.org/en/stable/web.html
[2] Soon available at http://github.com/globocom/brainiak
