### PR TITLE
Only add ``Access`` headers when ``Origin`` present.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readfile(file_name):
 
 setup(
     name='tornado-cors',
-    version='0.4.0',
+    version='0.4.1',
     keywords='tornado cors',
     author='globo.com',
     author_email='guilherme.cirne@corp.globo.com',


### PR DESCRIPTION
According to the spec, an `Origin` header doesn't necesarrily mean a
request is a CORS request **but** every CORS request will have an
`Origin` header.

From the [spec](http://www.w3.org/TR/cors/):

For "simple" CORS requests and "preflight" requests:

> If the Origin header is not present terminate this set of steps. The request is outside the scope of this specification.
