### PR TITLE
Full Support of CORS Spec

### DIFF
--- a/tests/test_tornado_cors.py
+++ b/tests/test_tornado_cors.py
@@ -23,46 +23,6 @@ def custom_wrapper(method):
     return wrapper
 
 
-class CorsTestCase(AsyncHTTPTestCase):
-
-    def test_should_return_headers_with_default_values_in_options_request(self):
-        self.http_client.fetch(self.get_url('/default'), self.stop, method='OPTIONS')
-        headers = self.wait().headers
-
-        self.assertNotIn('Access-Control-Allow-Origin', headers)
-        self.assertNotIn('Access-Control-Allow-Headers', headers)
-        self.assertNotIn('Access-Control-Allow-Credentials', headers)
-        self.assertEqual(headers['Access-Control-Allow-Methods'], 'POST, DELETE, PUT, OPTIONS')
-        self.assertEqual(headers['Access-Control-Max-Age'], '86400')
-
-    def test_should_return_headers_with_custom_values_in_options_request(self):
-        self.http_client.fetch(self.get_url('/custom'), self.stop, method='OPTIONS')
-        headers = self.wait().headers
-        self.assertEqual(headers['Access-Control-Allow-Origin'], '*')
-        self.assertEqual(headers['Access-Control-Allow-Headers'], 'Content-Type')
-        self.assertEqual(headers['Access-Control-Allow-Methods'], 'POST')
-        self.assertEqual(headers['Access-Control-Allow-Credentials'], 'true')
-        self.assertNotIn('Access-Control-Max-Age', headers)
-
-    def test_should_return_origin_header_for_requests_other_than_options(self):
-        self.http_client.fetch(self.get_url('/custom'), self.stop, method='POST', body='')
-        headers = self.wait().headers
-        self.assertEqual(headers['Access-Control-Allow-Origin'], '*')
-
-    def test_should_support_custom_methods(self):
-        response = self.http_client.fetch(self.get_url('/custom_method'), self.stop, method='OPTIONS')
-        headers = self.wait().headers
-        self.assertEqual(headers["Access-Control-Allow-Methods"], 'OPTIONS, NEW_METHOD')
-
-    def test_should_support_custom_methods(self):
-        response = self.http_client.fetch(self.get_url('/custom_method'), self.stop, method='OPTIONS')
-        headers = self.wait().headers
-        self.assertEqual(headers["Access-Control-Allow-Methods"], 'OPTIONS, NEW_METHOD')
-
-    def get_app(self):
-        return Application([(r'/default', DefaultValuesHandler), (r'/custom', CustomValuesHandler), (r'/custom_method', CustomMethodValuesHandler)])
-
-
 class CustomWrapperTestCase(AsyncHTTPTestCase):
 
     def setUp(self):
@@ -94,7 +54,66 @@ class CustomWrapperTestCase(AsyncHTTPTestCase):
         self.assertEquals(cors.custom_decorator.wrapper, custom_wrapper)
 
 
+class DefaultValuesTestCase(AsyncHTTPTestCase):
+    """
+    Tests a handler that implements all default CORS settings.
+    """
+    def test_no_origin_header_options_request(self):
+        """
+        When an ``Origin`` header is not included in the request, no
+        ``Access-Control-*`` headers should be included.
+        """
+        self.http_client.fetch(self.get_url('/default'), self.stop, method='OPTIONS')
+        headers = self.wait().headers
+
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_ORIGIN, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_HEADERS, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_CREDENTIALS, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_METHODS, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_MAX_AGE, headers)
+
+    def test_preflight_options_request(self):
+        """
+        Test sending an OPTIONS request to a handler with default CORS
+        settings.
+        """
+        origin = DefaultValuesHandler.CORS_ORIGIN_WHITELIST[0]
+        expected_methods = 'POST, DELETE, PUT, OPTIONS'
+        self.http_client.fetch(self.get_url('/default'), self.stop, method='OPTIONS',
+            headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_ORIGIN], origin)
+        self.assertEqual(int(headers[cors.ACCESS_CONTROL_MAX_AGE]), 86400)
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_METHODS], expected_methods)
+
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_HEADERS, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_CREDENTIALS, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_EXPOSE_HEADERS, headers)
+
+    def test_get_request(self):
+        """
+        Test sending a GET request to a handler with (mostly) default CORS
+        settings.
+        """
+        origin = DefaultValuesHandler.CORS_ORIGIN_WHITELIST[0]
+        self.http_client.fetch(self.get_url('/default'), self.stop, method='GET',
+            headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_ORIGIN], origin)
+
+        self.assertNotIn(cors.ACCESS_CONTROL_ALLOW_CREDENTIALS, headers)
+        self.assertNotIn(cors.ACCESS_CONTROL_EXPOSE_HEADERS, headers)
+
+    def get_app(self):
+        return Application([(r'/default', DefaultValuesHandler)])
+
+
 class DefaultValuesHandler(cors.CorsMixin, RequestHandler):
+    """
+    One settings 'CORS_ORIGIN_WHITELIST' is not set to default in order
+    to get the rest of the settings to function.
+    """
+    CORS_ORIGIN_WHITELIST = ['http://example.foo', ]
 
     @asynchronous
     def post(self):
@@ -109,11 +128,88 @@ class DefaultValuesHandler(cors.CorsMixin, RequestHandler):
         self.finish()
 
 
+class HasOptionsMethodTestCase(AsyncHTTPTestCase):
+    """
+    Tests a handler that implements it's own OPTIONS method that should be
+    called on Non-CORS OPTIONS requests.
+    """
+    def test_options_request_with_no_origin(self):
+        """
+        This test hits a handler that has it's own ``options`` method without
+        an ``Origin`` header. In this case, the non-preflight OPTIONS
+        response should be returned.
+        """
+        self.http_client.fetch(self.get_url('/has_options_method'), self.stop,
+            method='OPTIONS')
+        body = self.wait().body
+        self.assertIn('Non-CORS', body)
+
+    def get_app(self):
+        return Application([(r'/has_options_method', HasOptionsMethodHandler)])
+
+
+class HasOptionsMethodHandler(cors.CorsMixin, RequestHandler):
+    """
+    CORS enabled can have their own OPTIONS methods. If they receive an OPTIONS
+    request but no ``Origin`` header, the non-preflight OPTIONS method should
+    respond.
+
+    This handler allows the above case to be tested.
+    """
+    @asynchronous
+    def options(self):
+        self.write('Non-CORS OPTIONS responding')
+        self.finish()
+
+
+class CustomValuesTestCase(AsyncHTTPTestCase):
+    """
+    Test resposes from a handler that has custom settings.
+    """
+    def test_preflight_options_request(self):
+        """
+        Test sending a preflight OPTIONS request.
+        """
+        origin = CustomValuesHandler.CORS_ORIGIN_WHITELIST[0]
+        self.http_client.fetch(self.get_url('/custom'), self.stop, method='OPTIONS',
+            headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_ORIGIN], origin)
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_METHODS],
+            CustomValuesHandler.CORS_ALLOW_METHODS)
+
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_HEADERS],
+            CustomValuesHandler.CORS_ALLOW_HEADERS)
+        self.assertEqual(headers[cors.ACCESS_CONTROL_EXPOSE_HEADERS],
+            CustomValuesHandler.CORS_EXPOSE_HEADERS)
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_CREDENTIALS], 'true')
+
+        self.assertNotIn('Access-Control-MaxAge', headers)
+
+    def test_post_request(self):
+        """
+        Test sending a POST request.
+        """
+        origin = CustomValuesHandler.CORS_ORIGIN_WHITELIST[0]
+        self.http_client.fetch(self.get_url('/custom'), self.stop, method='OPTIONS',
+            headers={'Origin': origin})
+        headers = self.wait().headers
+
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_ORIGIN], origin)
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_CREDENTIALS], 'true')
+        self.assertEqual(headers[cors.ACCESS_CONTROL_EXPOSE_HEADERS],
+            CustomValuesHandler.CORS_EXPOSE_HEADERS)
+
+    def get_app(self):
+        return Application([(r'/custom', CustomValuesHandler)])
+
+
 class CustomValuesHandler(cors.CorsMixin, RequestHandler):
 
-    CORS_ORIGIN = '*'
-    CORS_HEADERS = 'Content-Type'
-    CORS_METHODS = 'POST'
+    CORS_ORIGIN_WHITELIST = ['http://example.foo', ]
+    CORS_ALLOW_HEADERS = 'Content-Length'
+    CORS_EXPOSE_HEADERS = 'Content-Length'
+    CORS_ALLOW_METHODS = 'POST'
     CORS_CREDENTIALS = True
     CORS_MAX_AGE = None
 
@@ -130,8 +226,127 @@ class CustomValuesHandler(cors.CorsMixin, RequestHandler):
         self.finish()
 
 
+class WhitelistTestCase(AsyncHTTPTestCase):
+    """
+    Test responses from a handler that has a ``CORS_ORIGIN_WHITELIST`` setting.
+    """
+    def test_whitelist_match(self):
+        """
+        Pass an origin header that is included in the whitelist.
+        """
+        origin = 'http://example.foo'
+        self.http_client.fetch(self.get_url('/whitelist_handler'), self.stop,
+            method='OPTIONS', headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertEqual(headers['Access-Control-Allow-Origin'], origin)
+        self.assertEqual(headers['Access-Control-Allow-Methods'], 'GET, OPTIONS')
+
+    def test_whitelist_miss(self):
+        """
+        Pass an origin header that is not included in the whitelist
+        """
+        origin = 'http://notwhitelisted.foo'
+        self.http_client.fetch(self.get_url('/whitelist_handler'), self.stop,
+            method='OPTIONS', headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertNotIn('Access-Control-Allow-Origin', headers)
+
+    def test_whitelist_scheme_miss(self):
+        """
+        Pass an origin header for a domain that is whitelisted but a different
+        URL scheme. In this case, the domain is whitelisted for https traffic
+        but not plain http.
+        """
+        origin = 'http://nohttpexample.foo'
+        self.http_client.fetch(self.get_url('/whitelist_handler'), self.stop,
+            method='OPTIONS', headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertNotIn('Access-Control-Allow-Origin', headers)
+
+    def get_app(self):
+        return Application([(r'/whitelist_handler', WhitelistHandler)])
+
+
+class WhitelistHandler(cors.CorsMixin, RequestHandler):
+    """
+    Handler that implements the ``CORS_ORIGIN_WHITELIST`` setting.
+    """
+    CORS_ORIGIN_WHITELIST = ['http://example.foo', 'https://example.foo',
+        'https://nohttpexample.foo']
+    CORS_CREDENTIALS = None
+    CORS_MAX_AGE = None
+
+    @asynchronous
+    def get(self):
+        self.finish()
+
+
+class RegexWhitelistTestCase(AsyncHTTPTestCase):
+    """
+    Test responses from a handler that has a ``CORS_ORIGIN_REGEX_WHITELIST``
+    setting.
+    """
+    def test_regex_whitelist_hit(self):
+        """
+        Pass an origin header that should be whitelisted by a set regex.
+        """
+        origin = 'http://example.foo'
+        self.http_client.fetch(self.get_url('/regex_whitelist_handler'), self.stop,
+            method='OPTIONS', headers={'Origin': origin})
+        response = self.wait()
+        self.assertEqual(response.code, 204)
+        self.assertIn('Access-Control-Allow-Origin', response.headers)
+
+    def test_regex_whitelist_miss(self):
+        """
+        Pass an origin header that should not be whitelisted by a set regex.
+        """
+        origin = 'http://bad.foo'
+        self.http_client.fetch(self.get_url('/regex_whitelist_handler'), self.stop,
+            method='OPTIONS', headers={'Origin': origin})
+        response = self.wait()
+        self.assertTrue(response.code, 405)
+        self.assertNotIn('Access-Control-Allow-Origin', response.headers)
+
+    def get_app(self):
+        return Application([(r'/regex_whitelist_handler', RegexWhitelistHandler)])
+
+class RegexWhitelistHandler(cors.CorsMixin, RequestHandler):
+    """
+    Handler that implements the ``CORS_ORIGIN_REGEX_WHITELIST`` setting.
+    """
+    # allow CORS requets from both http and https at example.foo
+    CORS_ORIGIN_REGEX_WHITELIST = ['http[s]?\://example\.foo', ]
+    CORS_CREDENTIALS = None
+    CORS_MAX_AGE = None
+
+    @asynchronous
+    def get(self):
+        self.finish()
+
+
+class CustomMethodTestCase(AsyncHTTPTestCase):
+    """
+    Test a handler with a custom HTTP method.
+    """
+    def test_preflight_options_method(self):
+        """
+        Test sending a preflight OPTIONS request.
+        """
+        origin = 'http://example.foo'
+        self.http_client.fetch(self.get_url('/custom_method'), self.stop,
+            method='OPTIONS', headers={'Origin': origin})
+        headers = self.wait().headers
+        self.assertEqual(headers[cors.ACCESS_CONTROL_ALLOW_METHODS],
+            'OPTIONS, NEW_METHOD')
+
+    def get_app(self):
+        return Application([(r'/custom_method', CustomMethodValuesHandler)])
+
+
 class CustomMethodValuesHandler(cors.CorsMixin, RequestHandler):
 
+    CORS_ALLOW_ALL_ORIGINS = True
     SUPPORTED_METHODS = list(CustomValuesHandler.SUPPORTED_METHODS) + ["NEW_METHOD"]
 
     @asynchronous

--- a/tornado_cors/__init__.py
+++ b/tornado_cors/__init__.py
@@ -1,10 +1,22 @@
 # -*- coding: utf-8 -*-
 
-
 import inspect
+import logging
+import re
+
 
 from tornado.web import RequestHandler
 from tornado_cors import custom_decorator
+
+logger = logging.getLogger(__name__)
+
+
+ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
+ACCESS_CONTROL_EXPOSE_HEADERS = 'Access-Control-Expose-Headers'
+ACCESS_CONTROL_ALLOW_CREDENTIALS = 'Access-Control-Allow-Credentials'
+ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
+ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods'
+ACCESS_CONTROL_MAX_AGE = 'Access-Control-Max-Age'
 
 
 def _get_class_that_defined_method(meth):
@@ -14,36 +26,66 @@ def _get_class_that_defined_method(meth):
 
 
 class CorsMixin(object):
+    """
+    Add CORS header support to a Tornado RequestHandler.
+    """
 
-    CORS_ORIGIN = None
-    CORS_HEADERS = None
-    CORS_METHODS = None
-    CORS_CREDENTIALS = None
+    CORS_ALLOW_ALL_ORIGINS = False
+    CORS_ALLOW_HEADERS = None
+    CORS_EXPOSE_HEADERS = None
+    CORS_ALLOW_METHODS = None
+    CORS_CREDENTIALS = False
     CORS_MAX_AGE = 86400
+    CORS_ORIGIN_WHITELIST = []
+    CORS_ORIGIN_REGEX_WHITELIST = []
 
     def set_default_headers(self):
-        if self.CORS_ORIGIN:
-            self.set_header("Access-Control-Allow-Origin", self.CORS_ORIGIN)
+        origin = self.request.headers.get('Origin')
+        if self.should_add_cors_headers(origin):
+            logger.debug('Including %s header', ACCESS_CONTROL_ALLOW_ORIGIN)
+            allow_origin = '*' if self.CORS_ALLOW_ALL_ORIGINS else origin
+            self.set_header(ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin)
+
+            if self.CORS_CREDENTIALS == True:
+                logger.debug('Including %s header', ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                self.set_header(ACCESS_CONTROL_ALLOW_CREDENTIALS, 'true')
+
+            if self.CORS_EXPOSE_HEADERS != None:
+                self.set_header('Access-Control-Expose-Headers',self.CORS_EXPOSE_HEADERS)
 
     @custom_decorator.wrapper
     def options(self, *args, **kwargs):
-        if self.CORS_HEADERS:
-            self.set_header('Access-Control-Allow-Headers', self.CORS_HEADERS)
-        if self.CORS_METHODS:
-            self.set_header('Access-Control-Allow-Methods', self.CORS_METHODS)
+        logger.debug('Processing CORS preflight OPTIONS request')
+        origin = self.request.headers.get('Origin')
+        if self.should_add_cors_headers(origin):
+
+            # always include methods
+            logger.debug('Including %s header', ACCESS_CONTROL_ALLOW_METHODS)
+            self.set_header(ACCESS_CONTROL_ALLOW_METHODS, self._get_methods())
+
+            if self.CORS_ALLOW_HEADERS:
+                logger.debug('Including %s header', ACCESS_CONTROL_ALLOW_HEADERS)
+                self.set_header(ACCESS_CONTROL_ALLOW_HEADERS, self.CORS_ALLOW_HEADERS)
+
+            if self.CORS_MAX_AGE:
+                logger.debug('Including %s header', ACCESS_CONTROL_MAX_AGE)
+                self.set_header(ACCESS_CONTROL_MAX_AGE, self.CORS_MAX_AGE)
+
+            self.set_status(204)
+            self.finish()
         else:
-            self.set_header('Access-Control-Allow-Methods', self._get_methods())
-        if self.CORS_CREDENTIALS != None:
-            self.set_header('Access-Control-Allow-Credentials',
-                "true" if self.CORS_CREDENTIALS else "false")
-        if self.CORS_MAX_AGE:
-            self.set_header('Access-Control-Max-Age', self.CORS_MAX_AGE)
-        self.set_status(204)
-        self.finish()
+            super(CorsMixin, self).options(*args, **kwargs)
 
     def _get_methods(self):
+        if self.CORS_ALLOW_METHODS != None:
+            logger.debug('Using methods from handler CORS_METHOD setting')
+            return self.CORS_ALLOW_METHODS
+
+        logger.debug('Introspecting handler for method list')
+
+        # CORS methods not explicitly set, introspect the handler and include
+        # all HTTP verb related methods.
         supported_methods = [method.lower() for method in self.SUPPORTED_METHODS]
-        #  ['get', 'put', 'post', 'patch', 'delete', 'options']
         methods = []
         for meth in supported_methods:
             instance_meth = getattr(self, meth)
@@ -54,3 +96,31 @@ class CorsMixin(object):
                 methods.append(meth.upper())
 
         return ", ".join(methods)
+
+    def should_add_cors_headers(self, origin_header_val):
+        """
+        Indicate whether or not CORS headers should be supplied for a request
+        from ``origin_header_val``.
+        """
+        thing = (origin_header_val is not None and
+            (self._check_origin_whitelist(origin_header_val) or
+            self.CORS_ALLOW_ALL_ORIGINS))
+        return thing
+
+    def _check_origin_whitelist(self, origin_header_val):
+        """
+        Check the Origin header value against a list of
+        whitelisted origins and whitelisted origin regexes. Return ``True`` if
+        the Origin is found, ``False`` if it is not.
+        """
+        return (origin_header_val in self.CORS_ORIGIN_WHITELIST or
+                self._check_regex_origin_whitelist(origin_header_val))
+
+    def _check_regex_origin_whitelist(self, origin_header_val):
+        """
+        Check the Origin header value against a whitelisted origin regexes.
+        Return ``True`` if a match if found, ``False`` if not.
+        """
+        for domain_pattern in self.CORS_ORIGIN_REGEX_WHITELIST:
+            if re.match(domain_pattern, origin_header_val):
+                return True


### PR DESCRIPTION
Hi! **This isn't ready to merge** but I wanted to start a conversation around it. I apologize for leaving my [other PR](https://github.com/globocom/tornado-cors/pull/8) handging. I needed to get CORS into a project I'm working on quickly. The added overhead of supporting multiple Python versions was going to slow me down a bit so I wrote most of what's in this PR inside of the other project. I'd like to contribute the changes if y'all will accept them (after doc updates and fixing tests for Python 3.X, etc. of course). If this isn't a direction y'all would like to go, I totally understand.

Cheers.

Updates include:
##### Only include CORS headers when an `Origin` header is present in the request.

While an `Origin` header does not necessarily indicate a CORS request,
all CORS requests will contain an `Origin` header.
##### Support for the [Access-Control-Expose-Headers](http://www.w3.org/TR/cors/#access-control-expose-headers-response-header)
##### Support multiple origins with whitelist settings and regular expressions

This idea was borrowed from [django-cors-headers](https://github.com/ottoyiu/django-cors-headers#configuration).
While it isn't implemented exactly the same, the concept is very
similar.
##### Credential header on all CORS requests when set
##### Test cases and associated handlers are aimed at one specific use case.
#### Breaking Changes

Many of the settings attributes have updated names to more explicitly
link them to the headers they control. The catalyst for this was
supporting both Allow-Headers and Expose-Headers.
