### PR TITLE
Added support for Access-Control-Expose-Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ class MyHandler(CorsMixin, RequestHandler):
     # Default: 86400.
     # None means no header.
     CORS_MAX_AGE = 21600
+
+    # Value for the Access-Control-Expose-Headers header.
+    # Default: None
+    CORS_EXPOSE_HEADERS = 'Location, X-WP-TotalPages'
     
     ...
 ```

--- a/tornado_cors/__init__.py
+++ b/tornado_cors/__init__.py
@@ -20,6 +20,7 @@ class CorsMixin(object):
     CORS_METHODS = None
     CORS_CREDENTIALS = None
     CORS_MAX_AGE = 86400
+    CORS_EXPOSE_HEADERS = None
 
     def set_default_headers(self):
         if self.CORS_ORIGIN:
@@ -38,6 +39,10 @@ class CorsMixin(object):
                 "true" if self.CORS_CREDENTIALS else "false")
         if self.CORS_MAX_AGE:
             self.set_header('Access-Control-Max-Age', self.CORS_MAX_AGE)
+
+        if self.CORS_EXPOSE_HEADERS:
+            self.set_header('Access-Control-Expose-Headers', self.CORS_EXPOSE_HEADERS)
+
         self.set_status(204)
         self.finish()
 


### PR DESCRIPTION
Access-Control-Expose-Headers is required to allow XHR requests to have access to 'unsafe' headers from requests which includes the `Location` header