### PR TITLE
Access control expose headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ class MyHandler(CorsMixin, RequestHandler):
     # Default: 86400.
     # None means no header.
     CORS_MAX_AGE = 21600
+
+    # Value for the Access-Control-Expose-Headers header.
+    # Default: None
+    CORS_EXPOSE_HEADERS = 'Location, X-WP-TotalPages'
     
     ...
 ```

--- a/tests/test_tornado_cors.py
+++ b/tests/test_tornado_cors.py
@@ -32,6 +32,7 @@ class CorsTestCase(AsyncHTTPTestCase):
         self.assertNotIn('Access-Control-Allow-Origin', headers)
         self.assertNotIn('Access-Control-Allow-Headers', headers)
         self.assertNotIn('Access-Control-Allow-Credentials', headers)
+        self.assertNotIn('Access-Control-Expose-Headers', headers)
         self.assertEqual(headers['Access-Control-Allow-Methods'], 'POST, DELETE, PUT, OPTIONS')
         self.assertEqual(headers['Access-Control-Max-Age'], '86400')
 
@@ -42,12 +43,14 @@ class CorsTestCase(AsyncHTTPTestCase):
         self.assertEqual(headers['Access-Control-Allow-Headers'], 'Content-Type')
         self.assertEqual(headers['Access-Control-Allow-Methods'], 'POST')
         self.assertEqual(headers['Access-Control-Allow-Credentials'], 'true')
+        self.assertEqual(headers['Access-Control-Expose-Headers'], 'Location')
         self.assertNotIn('Access-Control-Max-Age', headers)
 
     def test_should_return_origin_header_for_requests_other_than_options(self):
         self.http_client.fetch(self.get_url('/custom'), self.stop, method='POST', body='')
         headers = self.wait().headers
         self.assertEqual(headers['Access-Control-Allow-Origin'], '*')
+        self.assertEqual(headers['Access-Control-Expose-Headers'], 'Location')
 
     def test_should_support_custom_methods(self):
         response = self.http_client.fetch(self.get_url('/custom_method'), self.stop, method='OPTIONS')
@@ -116,6 +119,7 @@ class CustomValuesHandler(cors.CorsMixin, RequestHandler):
     CORS_METHODS = 'POST'
     CORS_CREDENTIALS = True
     CORS_MAX_AGE = None
+    CORS_EXPOSE_HEADERS = 'Location'
 
     @asynchronous
     def post(self):

--- a/tornado_cors/__init__.py
+++ b/tornado_cors/__init__.py
@@ -20,6 +20,7 @@ class CorsMixin(object):
     CORS_METHODS = None
     CORS_CREDENTIALS = None
     CORS_MAX_AGE = 86400
+    CORS_EXPOSE_HEADERS = None
 
     def set_default_headers(self):
         if self.CORS_ORIGIN:
@@ -38,6 +39,10 @@ class CorsMixin(object):
                 "true" if self.CORS_CREDENTIALS else "false")
         if self.CORS_MAX_AGE:
             self.set_header('Access-Control-Max-Age', self.CORS_MAX_AGE)
+
+        if self.CORS_EXPOSE_HEADERS:
+            self.set_header('Access-Control-Expose-Headers', self.CORS_EXPOSE_HEADERS)
+
         self.set_status(204)
         self.finish()
 

--- a/tornado_cors/__init__.py
+++ b/tornado_cors/__init__.py
@@ -26,6 +26,9 @@ class CorsMixin(object):
         if self.CORS_ORIGIN:
             self.set_header("Access-Control-Allow-Origin", self.CORS_ORIGIN)
 
+        if self.CORS_EXPOSE_HEADERS:
+            self.set_header('Access-Control-Expose-Headers', self.CORS_EXPOSE_HEADERS)
+
     @custom_decorator.wrapper
     def options(self, *args, **kwargs):
         if self.CORS_HEADERS:


### PR DESCRIPTION
Access-Control-Expose-Headers is required to allow XHR requests to have access to 'unsafe' headers from requests which includes the Location header.