### PR TITLE
Enabling Tornado 4.x support. Working without any known issues.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tornado<4.0.0
+tornado

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readfile(file_name):
 
 setup(
     name='tornado-cors',
-    version='0.5.0',
+    version='0.6.0',
     description='CORS support for Tornado',
     keywords='tornado cors',
     author='globo.com',


### PR DESCRIPTION
Raising version number to 0.6.0.